### PR TITLE
Can not generate paginator url because route params not found

### DIFF
--- a/src/Resources/views/pager/bootstrap4.html.twig
+++ b/src/Resources/views/pager/bootstrap4.html.twig
@@ -6,7 +6,7 @@
       </div>
       <select class="custom-select" onchange="location.href=this.querySelector('option:checked').getAttribute('data-link')">
         {% for limit in selectable_limits|default([10, 25, 50, 100, 250, 500]) %}
-          <option data-link="{{ path(route, queries|merge({(limit_name): limit, (page_name): 1})) }}" {% if limit == limit_current %}selected{% endif %}>
+          <option data-link="{{ path(route, queries|merge(route_params)|merge({(limit_name): limit, (page_name): 1})) }}" {% if limit == limit_current %}selected{% endif %}>
             {% block select_option_text %}{{ limit }}{% endblock %}
           </option>
         {% endfor %}
@@ -17,7 +17,7 @@
     {% block left %}
       {% if page_left > page_first %}
         <li class="page-item">
-          <a href="{{ path(route, queries|merge({(page_name): 1})) }}" class="page-link">1</a>
+          <a href="{{ path(route, queries|merge(route_params)|merge({(page_name): 1})) }}" class="page-link">1</a>
         </li>
       {% endif %}
       {% if page_left > page_first + 1 %}
@@ -28,7 +28,7 @@
     {% endblock %}
 
     {% for page in page_left..page_right %}
-      {% set url = path(route, queries|merge({(page_name): page})) %}
+      {% set url = path(route, queries|merge(route_params)|merge({(page_name): page})) %}
       {% if page == page_current %}
         <li class="page-item active">
           <span class="page-link">
@@ -52,7 +52,7 @@
       {% endif %}
       {% if page_right < page_last %}
         <li class="page-item">
-          <a href="{{ path(route, queries|merge({(page_name): page_last})) }}" class="page-link">{{ page_last }}</a>
+          <a href="{{ path(route, queries|merge(route_params)|merge({(page_name): page_last})) }}" class="page-link">{{ page_last }}</a>
         </li>
       {% endif %}
     {% endblock %}

--- a/src/Resources/views/pager/default.html.twig
+++ b/src/Resources/views/pager/default.html.twig
@@ -24,7 +24,7 @@
   {% block limit_selector %}
     <select class="limit-selector" onchange="location.href=this.querySelector('option:checked').getAttribute('data-link')">
       {% for limit in selectable_limits|default([10, 25, 50, 100, 250, 500]) %}
-        <option data-link="{{ path(route, queries|merge({(limit_name): limit, (page_name): 1})) }}" {% if limit == limit_current %}selected{% endif %}>
+        <option data-link="{{ path(route, queries|merge(route_params)|merge({(limit_name): limit, (page_name): 1})) }}" {% if limit == limit_current %}selected{% endif %}>
           {{ limit }}
         </option>
       {% endfor %}
@@ -35,7 +35,7 @@
     <ul class="pager">
       {% block left %}
         {% if page_left > page_first %}
-          <li><a href="{{ path(route, queries|merge({(page_name): 1})) }}">1</a></li>
+          <li><a href="{{ path(route, queries|merge(route_params)|merge({(page_name): 1})) }}">1</a></li>
         {% endif %}
         {% if page_left > page_first + 1 %}
           <li class="disabled">...</li>
@@ -44,7 +44,7 @@
 
       {% block range %}
         {% for page in page_left..page_right %}
-          {% set url = path(route, queries|merge({(page_name): page})) %}
+          {% set url = path(route, queries|merge(route_params)|merge({(page_name): page})) %}
           {% if page == page_current %}
             <li class="active"><span>{{ page }}</span></li>
           {% else %}
@@ -58,7 +58,7 @@
           <li class="disabled">...</li>
         {% endif %}
         {% if page_right < page_last %}
-          <li><a href="{{ path(route, queries|merge({(page_name): page_last})) }}">{{ page_last }}</a></li>
+          <li><a href="{{ path(route, queries|merge(route_params)|merge({(page_name): page_last})) }}">{{ page_last }}</a></li>
         {% endif %}
       {% endblock %}
     </ul>

--- a/src/Resources/views/sortable/default.html.twig
+++ b/src/Resources/views/sortable/default.html.twig
@@ -1,5 +1,5 @@
 <span class="{% block direction_class %}{{ direction_class_prefix|default('') ~ direction_current ~ direction_class_postfix|default('') }}{% endblock %}">
-  <a href="{{ path(route, queries|merge({(key_name): key, (direction_name): direction_next})) }}">
+  <a href="{{ path(route, queries|merge(route_params)|merge({(key_name): key, (direction_name): direction_next})) }}">
     {% block text %}{{ text }}{% endblock %}
   </a>
 </span>

--- a/src/Twig/TtskchPaginatorExtension.php
+++ b/src/Twig/TtskchPaginatorExtension.php
@@ -56,7 +56,8 @@ class TtskchPaginatorExtension extends AbstractExtension
 
         $context = array_merge($context, [
             'route' => $this->context->request ? $this->context->request->get('_route') : null,
-            'queries' => $this->context->request ?  array_merge($this->context->request->query->all(), $this->context->request->get('_route_params')) : [],
+            'route_params' => $this->context->request ? $this->context->request->get('_route_params') : null,
+            'queries' => $this->context->request ? $this->context->request->query->all(): [],
             'limit_name' => $this->context->config->limitName,
             'limit_current' => $this->context->criteria->limit,
             'page_name' => $this->context->config->pageName,
@@ -84,11 +85,12 @@ class TtskchPaginatorExtension extends AbstractExtension
         $nextDirection = $isSorted ? (strtolower($currentDirection) === 'asc' ? 'desc' : 'asc') : $this->context->config->sortDirectionDefault;
 
         // reset page number after re-sorting.
-        $queries = $this->context->request ?  array_merge($this->context->request->query->all(), $this->context->request->get('_route_params')) : [];
+        $queries = $this->context->request ? $this->context->request->query->all() : [];
         $queries[$this->context->config->pageName] = 1;
 
         $context = array_merge($context, [
             'route' => $this->context->request ? $this->context->request->get('_route') : null,
+            'route_params' => $this->context->request ? $this->context->request->get('_route_params') : null,
             'queries' => $queries,
             'key_name' => $this->context->config->sortKeyName,
             'key' => $key,

--- a/src/Twig/TtskchPaginatorExtension.php
+++ b/src/Twig/TtskchPaginatorExtension.php
@@ -56,7 +56,7 @@ class TtskchPaginatorExtension extends AbstractExtension
 
         $context = array_merge($context, [
             'route' => $this->context->request ? $this->context->request->get('_route') : null,
-            'queries' => $this->context->request ? $this->context->request->query->all() : [],
+            'queries' => $this->context->request ?  array_merge($this->context->request->query->all(), $this->context->request->get('_route_params')) : [],
             'limit_name' => $this->context->config->limitName,
             'limit_current' => $this->context->criteria->limit,
             'page_name' => $this->context->config->pageName,
@@ -84,7 +84,7 @@ class TtskchPaginatorExtension extends AbstractExtension
         $nextDirection = $isSorted ? (strtolower($currentDirection) === 'asc' ? 'desc' : 'asc') : $this->context->config->sortDirectionDefault;
 
         // reset page number after re-sorting.
-        $queries = $this->context->request ? $this->context->request->query->all() : [];
+        $queries = $this->context->request ?  array_merge($this->context->request->query->all(), $this->context->request->get('_route_params')) : [];
         $queries[$this->context->config->pageName] = 1;
 
         $context = array_merge($context, [


### PR DESCRIPTION
ページネーターを利用したページのURLにパラメータが含まれている場合に、正しくページネーターやソートのリンクが生成できませんでした。

このためパラメータを渡すように修正をしました。